### PR TITLE
Add the ability to use aws secrets with calls to kraken-lib

### DIFF
--- a/krak8s-api/templates/aws_secrets.yaml
+++ b/krak8s-api/templates/aws_secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.krak8s.cloudProvider == 'aws' }}
+---
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-aws-secret"
+  labels:
+    app: "{{ .Release.Name }}-{{ .Values.username }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  id: {{ .Values.krak8s.awsCredentials.id }}
+  key: {{ .Values.krak8s.awsCredentials.key }}
+  region: {{ .Values.krak8s.awsCredentials.region }}
+type: Opaque
+{{- end }}

--- a/krak8s-api/templates/deployment.yaml
+++ b/krak8s-api/templates/deployment.yaml
@@ -37,6 +37,23 @@ spec:
       - name: krak8s
         image: {{ .Values.krak8s.image }}:{{ .Values.krak8s.imageTag }}
         imagePullPolicy: {{ default "" .Values.krak8s.imagePullPolicy | quote }}
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Release.Name }}-aws-secret"
+                key: id 
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Release.Name }}-aws-secret"
+                key: key
+          - name: AWS_DEFAULT_REGION
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Release.Name }}-aws-secret"
+                key: region
+        
         ports:
         - name: api
           containerPort: 8080

--- a/krak8s-api/values.yaml
+++ b/krak8s-api/values.yaml
@@ -7,6 +7,12 @@ krak8s:
   imageTag: latest
   imagePullPolicy: Always
   imagePullSecret:
+  cloudProvider: none
+  awsCredentials:
+    # Each of the following values must be base64 encoded
+    id:
+    key:
+    region:
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
kraken-lib (formerly k2) is designed to pass AWS environment variables
for authentication and region selection. Add the ability to pass that
information through the krak8s pod.

To use this ability, add base64 encoded versions of the aws access key id
and secret to the values file passed to helm as documented in values.yaml.